### PR TITLE
backupstore: Add `LastBackupAt` field for volume

### DIFF
--- a/backupstore.go
+++ b/backupstore.go
@@ -12,6 +12,7 @@ type Volume struct {
 	Size           int64 `json:",string"`
 	CreatedTime    string
 	LastBackupName string
+	LastBackupAt   string
 	BlockCount     int64 `json:",string"`
 }
 

--- a/deltablock.go
+++ b/deltablock.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"github.com/rancher/backupstore/util"
+	"github.com/sirupsen/logrus"
 
 	. "github.com/rancher/backupstore/logging"
 )
@@ -209,6 +209,7 @@ func CreateDeltaBlockBackup(config *DeltaBackupConfig) (string, error) {
 	}
 
 	volume.LastBackupName = backup.Name
+	volume.LastBackupAt = backup.SnapshotCreatedAt
 	volume.BlockCount = volume.BlockCount + newBlocks
 
 	if err := saveVolume(volume, bsDriver); err != nil {
@@ -367,6 +368,7 @@ func DeleteDeltaBlockBackup(backupURL string) error {
 
 	if backup.Name == v.LastBackupName {
 		v.LastBackupName = ""
+		v.LastBackupAt = ""
 		if err := saveVolume(v, bsDriver); err != nil {
 			return err
 		}

--- a/list.go
+++ b/list.go
@@ -11,6 +11,7 @@ type VolumeInfo struct {
 	Size           int64 `json:",string"`
 	Created        string
 	LastBackupName string
+	LastBackupAt   string
 	SpaceUsage     int64 `json:",string"`
 
 	Messages       map[MessageType]string
@@ -105,6 +106,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 		Size:           volume.Size,
 		Created:        volume.CreatedTime,
 		LastBackupName: volume.LastBackupName,
+		LastBackupAt:   volume.LastBackupAt,
 		SpaceUsage:     int64(volume.BlockCount * DEFAULT_BLOCK_SIZE),
 		Messages:       make(map[MessageType]string),
 		Backups:        make(map[string]*BackupInfo),


### PR DESCRIPTION
It will record the time backup-based snapshot was taken, instead of when
backup started, since the snapshot created time is more meaningful to user.