### PR TITLE
backupstore: Rename volume.SpaceUsage to DataStored

### DIFF
--- a/list.go
+++ b/list.go
@@ -12,9 +12,9 @@ type VolumeInfo struct {
 	Created        string
 	LastBackupName string
 	LastBackupAt   string
-	SpaceUsage     int64 `json:",string"`
+	DataStored     int64 `json:",string"`
 
-	Messages       map[MessageType]string
+	Messages map[MessageType]string
 
 	Backups map[string]*BackupInfo `json:",omitempty"`
 }
@@ -50,9 +50,9 @@ func addListVolume(volumeName string, driver BackupStoreDriver, volumeOnly bool)
 	volume, err := loadVolume(volumeName, driver)
 	if err != nil {
 		return &VolumeInfo{
-			Name:           volumeName,
-			Messages:       map[MessageType]string {MessageTypeError : err.Error()},
-			Backups:        make(map[string]*BackupInfo),
+			Name:     volumeName,
+			Messages: map[MessageType]string{MessageTypeError: err.Error()},
+			Backups:  make(map[string]*BackupInfo),
 		}, nil
 	}
 
@@ -107,7 +107,7 @@ func fillVolumeInfo(volume *Volume) *VolumeInfo {
 		Created:        volume.CreatedTime,
 		LastBackupName: volume.LastBackupName,
 		LastBackupAt:   volume.LastBackupAt,
-		SpaceUsage:     int64(volume.BlockCount * DEFAULT_BLOCK_SIZE),
+		DataStored:     int64(volume.BlockCount * DEFAULT_BLOCK_SIZE),
 		Messages:       make(map[MessageType]string),
 		Backups:        make(map[string]*BackupInfo),
 	}

--- a/test/backup_test.go
+++ b/test/backup_test.go
@@ -249,7 +249,7 @@ func (s *TestSuite) TestBackupBasic(c *C) {
 	c.Assert(volumeInfo.Name, Equals, s.Volume.v.Name)
 	c.Assert(volumeInfo.Size, Equals, volumeSize)
 	c.Assert(volumeInfo.Created, Equals, s.Volume.v.CreatedTime)
-	c.Assert(volumeInfo.SpaceUsage, Equals, int64(snapshotCounts*backupstore.DEFAULT_BLOCK_SIZE))
+	c.Assert(volumeInfo.DataStored, Equals, int64(snapshotCounts*backupstore.DEFAULT_BLOCK_SIZE))
 	c.Assert(len(volumeInfo.Backups), Equals, snapshotCounts)
 
 	backupInfo0, ok := volumeInfo.Backups[backup0]


### PR DESCRIPTION
This is not the real space usage since all blocks are compressed